### PR TITLE
Some simple changes

### DIFF
--- a/MNAlertData.m
+++ b/MNAlertData.m
@@ -41,27 +41,33 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -(id)initWithHeader:(NSString*)_header withText:(NSString*)_title andType:(int)_type forBundleID:(NSString*)_bundleID atTime:(NSDate*)_time ofStatus:(int)_status
 {
-	self.header = [[NSString alloc] initWithString:_header];
-	self.text = [[NSString alloc] initWithString:_title];
-	self.bundleID = [[NSString alloc] initWithString:_bundleID];
-	self.time = _time;
+	if ((self = [self init]))
+	{
+		self.header = _header;
+		self.text = _title;
+		self.bundleID = _bundleID;
+		self.time = _time;
 
-	self.type = _type;
-	self.status = _status;
-
+		self.type = _type;
+		self.status = _status;
+	}
+	
 	return self;
 }
 
 -(id)initWithHeader:(NSString*)_header withText:(NSString*)_title andType:(int)_type forBundleID:(NSString*)_bundleID ofStatus:(int)_status
 {
-    self.header = [[NSString alloc] initWithString:_header];
-	self.text = [[NSString alloc] initWithString:_title];
-	self.bundleID = [[NSString alloc] initWithString:_bundleID];
-    self.time = [[NSDate date] retain];
-
-	self.type = _type;
-	self.status = _status;
-
+	if ((self = [self init]))
+	{
+    	self.header = _header;
+		self.text = _title;
+		self.bundleID = _bundleID;
+    	self.time = [NSDate date];
+	
+		self.type = _type;
+		self.status = _status;
+	}
+	
 	return self;
 }
 


### PR DESCRIPTION
1. If a property has the retain attribute and you set it with `self.property = value` then you do not need to retain the object, it is done automatically. Doing so will lead to double retaining the object, it not being released, and a memory leak.
2. You don't need to instantiate a second NSString to set an object's properties. The first one, passed as an argument is totally fine.

I didn't check the whole code for these mistakes, but its whatever.
