### PR TITLE
Here's the commit you asked for on notifications

### DIFF
--- a/MNWhistleBlowerController.m
+++ b/MNWhistleBlowerController.m
@@ -44,18 +44,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -(void)alertArrivedWithData:(MNAlertData*)data;
 {
-    // Have the device vibrate, if the ringer switch
-    // is flipped (and if the device supports it)
-    AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
-
-    // Play noise, if the ringer switch is not
-    // flipped (and if the device supports it)
-    // Don't do this for push notifications
-
-    if (data.type != kPushAlert)
-    {
-        AudioServicesPlaySystemSound(1007);
-    }
+    // Play sound as an alert so the phone vibrates as the user has set
+    // This needs the sound pulled from the system settings to play the
+    // Actual set ringtone. It will still play tritone.
+    // The setting is in com.apple.springboard.plist sms-sound-identifier
+    AudioServicesPlayAlertSound(1007);
 
     // Wake the device's screen
     [_delegate wakeDeviceScreen];

--- a/MNWhistleBlowerController.m
+++ b/MNWhistleBlowerController.m
@@ -44,11 +44,43 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -(void)alertArrivedWithData:(MNAlertData*)data;
 {
-    // Play sound as an alert so the phone vibrates as the user has set
-    // This needs the sound pulled from the system settings to play the
-    // Actual set ringtone. It will still play tritone.
-    // The setting is in com.apple.springboard.plist sms-sound-identifier
-    AudioServicesPlayAlertSound(1007);
+	// Get user setting for current notification tone on phone
+	NSString *filePath = @"/private/var/mobile/Library/Preferences/com.apple.springboard.plist";
+    NSMutableDictionary* plistDict = [[NSMutableDictionary alloc] initWithContentsOfFile:filePath];
+
+    NSString *smsTone;
+    smsTone = [plistDict objectForKey:@"sms-sound-identifier"];
+	
+	// Statements based on setting to play proper tone on phone
+	if ([smsTone isEqualToString:@"Tri-tone"])
+	{
+		AudioServicesPlayAlertSound(1007);
+	}
+	else if ([smsTone isEqualToString:@"texttone:Chime"])
+	{
+		AudioServicesPlayAlertSound(1008);
+	}
+	else if ([smsTone isEqualToString:@"texttone:Glass"])
+	{
+		AudioServicesPlayAlertSound(1009);
+	}
+	else if ([smsTone isEqualToString:@"texttone:Horn"])
+	{
+		AudioServicesPlayAlertSound(1010);
+	}
+	else if ([smsTone isEqualToString:@"texttone:Bell"])
+	{
+		AudioServicesPlayAlertSound(1013);
+	}
+	else if ([smsTone isEqualToString:@"texttone:Electronic"])
+	{
+		AudioServicesPlayAlertSound(1014);
+	}
+	else
+	{
+		// There be dragons here!
+    	AudioServicesPlayAlertSound(1007);
+	}
 
     // Wake the device's screen
     [_delegate wakeDeviceScreen];


### PR DESCRIPTION
I played with the code a little more and noticed that AudioServicesPlayAlertSound actually does all the legwork for you in regards to vibration so it only has to be 2 lines of code.

I know where the actual ringtone setting resides on ios but my knowledge of how to get it is minimal as I have no work with the private apis. It resides in /private/var/mobile/Library/Preferences/com.apple.springboard.plist under the key name sms-sound-identifier in the form texttone:Horn. I figure you could use a NSReader to get the value and use a method to convert the key contents to a system tone based on the returned key value. 

Unfortunately my knowledge of ios in general is rather lacking and as far as I can tell you need to use sandboxing to gain access to the file, although in jailbroken perhaps this is unnecessary. Anyways I figured this information might help you correct it entirely as the rest of the function is beyond my ability.
