### PR TITLE
Notification Bar Swiping

### DIFF
--- a/MNAlertManager.m
+++ b/MNAlertManager.m
@@ -274,6 +274,11 @@ void UIKeyboardDisableAutomaticAppearance(void);
     [lockscreen hide];
 }
 
+-(void)toggleLockWindowUserInteraction
+{
+    [lockscreen toggleLockWindowUserInteraction];
+}
+
 -(void)hideLockscreenPendingAlertsList
 {
     [lockscreen hidePendingAlertsList];
@@ -293,6 +298,16 @@ void UIKeyboardDisableAutomaticAppearance(void);
 
     // If the alert is expanded, then let's not have the alert go to "later"
     if (pendingAlertViewController.alertIsShowingPopOver) { return; }
+
+    // If pop over is not up and there has been a swipe, then reset the timer
+    else if (pendingAlertViewController.hasSwiped) {
+        [alertDismissTimer invalidate];
+        alertDismissTimer = [NSTimer scheduledTimerWithTimeInterval:15.0 target:self selector:@selector(alertShouldGoLaterTimerFired:) userInfo:nil repeats:NO];
+        
+        // Reset hasSwiped
+        [pendingAlertViewController setHasSwiped:NO];
+        return;
+    }
 
     [pendingAlertViewController laterPushed:nil];
 }

--- a/MNAlertManager.m
+++ b/MNAlertManager.m
@@ -111,7 +111,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 NSNumber *blackAlertStyleEnabled = [preferenceManager.preferences valueForKey:@"blackAlertStyleEnabled"];
                 bool isBlackAlertStyleEnabled    = blackAlertStyleEnabled ? [blackAlertStyleEnabled boolValue] : YES;
 
-                MNAlertViewController *viewController = [[MNAlertViewController alloc] initWithMNData:data];
+                MNAlertViewController *viewController = [[MNAlertViewController alloc] initWithMNData:data pendingAlerts:pendingAlerts];
 
                 viewController.useBlackAlertStyle = isBlackAlertStyleEnabled;
                 viewController.delegate    = self;
@@ -178,7 +178,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             NSNumber *blackAlertStyleEnabled = [preferenceManager.preferences valueForKey:@"blackAlertStyleEnabled"];
             bool isBlackAlertStyleEnabled    = blackAlertStyleEnabled ? [blackAlertStyleEnabled boolValue] : YES;
 
-            MNAlertViewController *viewController = [[MNAlertViewController alloc] initWithMNData:[pendingAlerts objectAtIndex:0]];
+            MNAlertViewController *viewController = [[MNAlertViewController alloc] initWithMNData:[pendingAlerts objectAtIndex:0] pendingAlerts:pendingAlerts];
             viewController.useBlackAlertStyle = isBlackAlertStyleEnabled;
             viewController.delegate    = self;
             pendingAlertViewController = viewController;
@@ -503,4 +503,3 @@ void UIKeyboardDisableAutomaticAppearance(void);
 }
 
 @end
-

--- a/MNAlertViewController.h
+++ b/MNAlertViewController.h
@@ -48,11 +48,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @interface MNAlertViewController : UIViewController <UITextViewDelegate>
 {
-    UIScrollView *notificationScrollView;
+    UIScrollView* notificationScrollView;
     UIView* notificationView;
     CGRect notificationViewRect;
     
     bool isAnimationInProgress;
+    bool hasSwiped;
     
     UIImageView* alertBackgroundImageView;
     UIImageView* iconImageView;
@@ -118,6 +119,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @property(readwrite) bool alertIsShowingPopOver;
 @property(readwrite) bool useBlackAlertStyle;
+@property(readwrite) bool hasSwiped;
 
 @property(nonatomic, retain) UILabel* alertHeaderLabel;
 @property(nonatomic, retain) UILabel* alertTextLabel;

--- a/MNAlertViewController.h
+++ b/MNAlertViewController.h
@@ -48,6 +48,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @interface MNAlertViewController : UIViewController <UITextViewDelegate>
 {
+    UIScrollView *notificationScrollView;
+    UIView* notificationView;
+    CGRect notificationViewRect;
+    
+    bool isAnimationInProgress;
+    
     UIImageView* alertBackgroundImageView;
     UIImageView* iconImageView;
 
@@ -73,13 +79,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     bool alertIsShowingPopOver;
     bool useBlackAlertStyle;
+    
+    NSMutableArray* pendingAlerts;
+    int index;
 
     MNAlertData* dataObj;
 
     id<MNAlertViewControllerDelegate> _delegate;
 }
 
--(id)initWithMNData:(MNAlertData*) data;
+-(id)initWithMNData:(MNAlertData*) data pendingAlerts:(NSMutableArray *)pendingAlerts;
+
+-(void)loadViewInfo;
+
+-(void)slideAwayRight;
+-(void)slideAwayLeft;
+-(void)slideIn;
 
 -(void)chevronPushed:(id)sender;
 
@@ -88,6 +103,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -(void)fadeInView;
 -(void)animationDidStop:(NSString*)animationID didFinish:(NSNumber*)finished inContext:(id)context;
 
+-(void)loadData;
 -(void)openPushed:(id)sender;
 -(void)laterPushed:(id)sender;
 -(void)closePushed:(id)sender;
@@ -110,4 +126,3 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @property(nonatomic, retain) UIButton* laterButton;
 
 @end
-

--- a/MNAlertViewController.m
+++ b/MNAlertViewController.m
@@ -45,6 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @synthesize dataObj;
 @synthesize alertIsShowingPopOver;
 @synthesize useBlackAlertStyle;
+@synthesize hasSwiped;
 
 @synthesize delegate = _delegate;
 
@@ -602,6 +603,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -(void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
     if (scrollView == notificationScrollView) {
+        [self setHasSwiped:YES];
+        
         // If scroll was far enough to the left
         if ([notificationScrollView contentOffset].x > 60) {
             [self slideAwayLeft];

--- a/MNAlertViewController.m
+++ b/MNAlertViewController.m
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2010-2011, Peter Hajas
 All rights reserved.
@@ -66,7 +65,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     dataObj = data;
     
-    // Might need to use a method for this and not an = operator?
     pendingAlerts = _pendingAlerts;
 
     return self;
@@ -275,7 +273,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         
         textBox = [[BCZeroEdgeTextView alloc] initWithFrame:CGRectMake(17.0, 145.0, 285.0, 50.0)];
         [textBox setDelegate:self];
-        // textBox.keyboardAppearance = UIKeyboardAppearanceAlert;      Semi-Transparent keyboard
+        textBox.keyboardAppearance = UIKeyboardAppearanceAlert;
         textBox.keyboardType = UIKeyboardTypeDefault;
         textBox.returnKeyType = UIReturnKeyDefault;
         textBox.font = [UIFont fontWithName:@"HelveticaNeue" size:12.500];

--- a/MNAlertViewController.m
+++ b/MNAlertViewController.m
@@ -1,3 +1,4 @@
+
 /*
 Copyright (c) 2010-2011, Peter Hajas
 All rights reserved.
@@ -602,9 +603,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -(void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (scrollView == notificationScrollView) {
+    if (scrollView == notificationScrollView)
+    {
         [self setHasSwiped:YES];
-        
+    }
+    else if (scrollView.contentOffset.x != 0.0)
+    {
+        [scrollView setContentOffset: CGPointMake(0.0, scrollView.contentOffset.y)];
+    }
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
+{
+    if (scrollView == notificationScrollView) {
         // If scroll was far enough to the left
         if ([notificationScrollView contentOffset].x > 60) {
             [self slideAwayLeft];
@@ -613,10 +624,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         else if ([notificationScrollView contentOffset].x < -60) {
             [self slideAwayRight];
         }
-    }
-    else if (scrollView.contentOffset.x != 0.0)
-    {
-        [scrollView setContentOffset: CGPointMake(0.0, scrollView.contentOffset.y)];
     }
 }
 

--- a/MNAlertViewController.m
+++ b/MNAlertViewController.m
@@ -1,3 +1,4 @@
+
 /*
 Copyright (c) 2010-2011, Peter Hajas
 All rights reserved.
@@ -59,11 +60,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     return self;
 }
 
--(id)initWithMNData:(MNAlertData*) data
+-(id)initWithMNData:(MNAlertData*) data pendingAlerts:(NSMutableArray *)_pendingAlerts
 {
     self = [super init];
 
     dataObj = data;
+    
+    // Might need to use a method for this and not an = operator?
+    pendingAlerts = _pendingAlerts;
 
     return self;
 }
@@ -71,7 +75,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -(void)loadView
 {
     [super loadView];
-
+    
+    // Set position of notificationView here
+    notificationViewRect = CGRectMake(0, 0, 320, 40);
+    
     self.view.frame = CGRectMake(0,0,320,40);
 
     [UIView setAnimationDidStopSelector:@selector(animationDidStop:didFinish:inContext:)];
@@ -90,24 +97,97 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         // Gray alert style
         alertBackgroundImageView.image = [UIImage imageWithContentsOfFile:@"/Library/Application Support/MobileNotifier/statusbar_alert_bg.png"];
     }
+    
+    alertExpandButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    alertExpandButton.frame = CGRectMake(0.0, 0.0, 320.0, 40.0);
+    [alertExpandButton setAlpha:0.0];
+    
+    // Popdown alert actions
+    alertActionBackgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(3.5, 30.0, 313.0, 229.0)];
+    alertActionBackgroundImageView.image = [UIImage imageWithContentsOfFile:@"/Library/Application Support/MobileNotifier/popout_bg.png"];
+    alertActionBackgroundImageView.opaque = NO;
+    alertActionBackgroundImageView.backgroundColor = [UIColor clearColor];
+    alertActionBackgroundImageView.alpha = 0.0;
+    
+    openButton = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
+    openButton.frame = CGRectMake(72.0, 205.0, 46.0, 40.0);
+    [openButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/btn_open.png"]
+                          forState:UIControlStateNormal];
+    [openButton setAlpha:0.0];
+    
+    laterButton = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
+    laterButton.frame = CGRectMake(16.0, 205.0, 46.0, 40.0);
+    [laterButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/btn_archive.png"]
+                           forState:UIControlStateNormal];
+    [laterButton setAlpha:0.0];
+    
+    closeButton = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
+    closeButton.frame = CGRectMake(274, 7.0, 25.0, 26.0);
+    
+    if (useBlackAlertStyle)
+    {
+        // Black alert style
+        [closeButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/statusbar_alert_dismiss_black.png"]
+                               forState:UIControlStateNormal];    }
+    else
+    {
+        // Gray alert style
+        [closeButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/statusbar_alert_dismiss.png"]
+                               forState:UIControlStateNormal];    }
+    
+    // Wire up buttons
+    [openButton addTarget:self action:@selector(openPushed:)
+         forControlEvents:UIControlEventTouchUpInside];
+    
+    [laterButton addTarget:self action:@selector(laterPushed:)
+          forControlEvents:UIControlEventTouchUpInside];
+    
+    [closeButton addTarget:self action:@selector(closePushed:)
+          forControlEvents:UIControlEventTouchUpInside];
+    
+    [alertExpandButton addTarget:self action:@selector(chevronPushed:)
+          forControlEvents:UIControlEventTouchUpInside];
 
+    // Add everything to our view
+    [self.view addSubview:alertBackgroundImageView];
+
+    // Release the stuff we don't want to hang on to
+    [alertBackgroundImageView release];
+
+    alertIsShowingPopOver = NO;
+
+    [self loadViewInfo];
+}
+
+-(void)loadViewInfo
+{
+    // Create and configure the scroll view
+    notificationScrollView = [[UIScrollView alloc] initWithFrame:CGRectMake(0, 0, 320, 40)];
+    [notificationScrollView setDelegate:self];
+    [notificationScrollView setAlwaysBounceHorizontal:YES];
+    [notificationScrollView setShowsHorizontalScrollIndicator:NO];
+    [self.view addSubview:notificationScrollView];
+    
+    // All notification data will go in this view. This way we can keep the
+    // background image seperate from the notification data. Makes swiping a lot better.
+    notificationView = [[UIView alloc] initWithFrame:notificationViewRect];
+    [notificationScrollView addSubview:notificationView];
+    
+    /* Draw the seperators */
+    
     iconImageView = [[UIImageView alloc] initWithFrame:CGRectMake(17.0, 9.0, 22.5, 22.5)];
     iconImageView.image = [_delegate iconForBundleID:dataObj.bundleID];
     [iconImageView setAlpha:0.0];
     iconImageView.layer.cornerRadius = 5.5;
     iconImageView.layer.masksToBounds = YES;
-
-    alertExpandButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    alertExpandButton.frame = CGRectMake(0.0, 0.0, 320.0, 40.0);
-    [alertExpandButton setAlpha:0.0];
-
+    
     alertHeaderLabel = [[UILabel alloc] initWithFrame:CGRectMake(49.0, 3.0, 216.0, 22.0)];
     alertHeaderLabel.adjustsFontSizeToFitWidth = NO;
     alertHeaderLabel.font = [UIFont fontWithName:@"HelveticaNeue-Bold" size:14.000];
     alertHeaderLabel.text = dataObj.header;
     alertHeaderLabel.textAlignment = UITextAlignmentLeft;
     alertHeaderLabel.backgroundColor = [UIColor clearColor];
-
+    
     if (useBlackAlertStyle)
     {
         // Black alert style
@@ -120,17 +200,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         alertHeaderLabel.textColor   = [UIColor colorWithRed:0.000 green:0.000 blue:0.000 alpha:0.9];
         alertHeaderLabel.shadowColor = [UIColor whiteColor];
     }
-
+    
     alertHeaderLabel.shadowOffset = CGSizeMake(0,1);
     [alertHeaderLabel setAlpha:0.0];
-
+    
     alertTextLabel = [[UILabel alloc] initWithFrame:CGRectMake(49.0, 17.0, 216.0, 22.0)];
     alertTextLabel.adjustsFontSizeToFitWidth = NO;
     alertTextLabel.font = [UIFont fontWithName:@"HelveticaNeue" size:11.000];
     alertTextLabel.text = dataObj.text;
     alertTextLabel.textAlignment = UITextAlignmentLeft;
     alertTextLabel.backgroundColor = [UIColor clearColor];
-
+    
     if (useBlackAlertStyle)
     {
         // Black alert style
@@ -143,10 +223,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         alertTextLabel.textColor = [UIColor colorWithRed:0.000 green:0.000 blue:0.000 alpha:0.9];
         alertTextLabel.shadowColor = [UIColor whiteColor];
     }
-
+    
     alertTextLabel.shadowOffset = CGSizeMake(0,1);
     [alertTextLabel setAlpha:0.0];
-
+    
     detailText = [[UITextView alloc] initWithFrame:CGRectMake(8.0, 50.0, 303.0, 75.0)];
     detailText.delegate = self;
     detailText.font = [UIFont fontWithName:@"HelveticaNeue" size:16.000];
@@ -156,7 +236,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     detailText.backgroundColor = [UIColor clearColor];
     detailText.editable = NO;
     [detailText setAlpha:0.0];
-
+    
     dateText = [[UILabel alloc] initWithFrame:CGRectMake(16.0, 127.0, 65.0, 15.0)];
     dateText.font = [UIFont fontWithName:@"HelveticaNeue" size:10.500];
     dateText.text = [dataObj.time descriptionWithCalendarFormat:@"%H:%M" timeZone: nil locale: nil];
@@ -164,53 +244,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     dateText.textColor = [UIColor colorWithRed:1.000 green:1.000 blue:1.000 alpha:0.5];
     dateText.backgroundColor = [UIColor clearColor];
     [dateText setAlpha:0.0];
-
-    // Popdown alert actions
-    alertActionBackgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(3.5, 30.0, 313.0, 229.0)];
-    alertActionBackgroundImageView.image = [UIImage imageWithContentsOfFile:@"/Library/Application Support/MobileNotifier/popout_bg.png"];
-    alertActionBackgroundImageView.opaque = NO;
-    alertActionBackgroundImageView.backgroundColor = [UIColor clearColor];
-    alertActionBackgroundImageView.alpha = 0.0;
-
-    openButton = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
-    openButton.frame = CGRectMake(72.0, 205.0, 46.0, 40.0);
-    [openButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/btn_open.png"]
-                          forState:UIControlStateNormal];
-    [openButton setAlpha:0.0];
-
-    laterButton = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
-    laterButton.frame = CGRectMake(16.0, 205.0, 46.0, 40.0);
-    [laterButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/btn_archive.png"]
-                           forState:UIControlStateNormal];
-    [laterButton setAlpha:0.0];
-
-    closeButton = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
-    closeButton.frame = CGRectMake(274, 7.0, 25.0, 26.0);
-
-    if (useBlackAlertStyle)
-    {
-        // Black alert style
-        [closeButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/statusbar_alert_dismiss_black.png"]
-                               forState:UIControlStateNormal];    }
-    else
-    {
-        // Gray alert style
-        [closeButton setBackgroundImage:[UIImage imageWithContentsOfFile: @"/Library/Application Support/MobileNotifier/statusbar_alert_dismiss.png"]
-                               forState:UIControlStateNormal];    }
-
-    // Wire up buttons
-    [openButton addTarget:self action:@selector(openPushed:)
-         forControlEvents:UIControlEventTouchUpInside];
-
-    [laterButton addTarget:self action:@selector(laterPushed:)
-          forControlEvents:UIControlEventTouchUpInside];
-
-    [closeButton addTarget:self action:@selector(closePushed:)
-             forControlEvents:UIControlEventTouchUpInside];
-
-    [alertExpandButton addTarget:self action:@selector(chevronPushed:)
-                forControlEvents:UIControlEventTouchUpInside];
-
+    
     // If we're an SMS alert, we have some more setup to do!
     if(dataObj.type == kSMSAlert)
     {
@@ -227,10 +261,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         sendButton.titleLabel.backgroundColor = [UIColor clearColor];
         sendButton.titleLabel.shadowColor = [UIColor blackColor];
         sendButton.titleLabel.shadowOffset = CGSizeMake(0,-1);
-
+        
         [sendButton addTarget:self action:@selector(sendPushed:)
-                forControlEvents:UIControlEventTouchUpInside];
-
+             forControlEvents:UIControlEventTouchUpInside];
+        
         charactersTyped = [[UILabel alloc] initWithFrame:CGRectMake(258.0, 127.0, 45.0, 15.0)];
         charactersTyped.font = [UIFont fontWithName:@"HelveticaNeue" size:10.500];
         charactersTyped.text = @"0/160";
@@ -238,38 +272,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         charactersTyped.textColor = [UIColor colorWithRed:1.000 green:1.000 blue:1.000 alpha:0.5];
         charactersTyped.backgroundColor = [UIColor clearColor];
         [charactersTyped setAlpha:0.0];
-
+        
         textBox = [[BCZeroEdgeTextView alloc] initWithFrame:CGRectMake(17.0, 145.0, 285.0, 50.0)];
         [textBox setDelegate:self];
-        textBox.keyboardAppearance = UIKeyboardAppearanceAlert;
+        // textBox.keyboardAppearance = UIKeyboardAppearanceAlert;      Semi-Transparent keyboard
         textBox.keyboardType = UIKeyboardTypeDefault;
         textBox.returnKeyType = UIReturnKeyDefault;
         textBox.font = [UIFont fontWithName:@"HelveticaNeue" size:12.500];
         textBox.textColor = [UIColor colorWithRed:0.000 green:0.000 blue:0.000 alpha:0.8];
         [textBox setAlpha:0.0];
     }
-
+        
     // Add everything to our view
-    [self.view addSubview:alertBackgroundImageView];
-    [self.view addSubview:iconImageView];
-    [self.view addSubview:alertHeaderLabel];
-    [self.view addSubview:alertTextLabel];
-    [self.view addSubview:alertExpandButton];
-
+    [notificationView addSubview:iconImageView];
+    [notificationView addSubview:alertHeaderLabel];
+    [notificationView addSubview:alertTextLabel];
+    [notificationView addSubview:alertExpandButton];
+    
     // Release the stuff we don't want to hang on to
-    [alertBackgroundImageView release];
     [alertHeaderLabel         release];
     [alertTextLabel           release];
-
-    alertIsShowingPopOver = NO;
-
+        
     [self fadeInView];
 }
 
 -(void)viewDidLoad
 {
     [super viewDidLoad];
-
+    
     // Detect single finger, double tap
     /*UITapGestureRecognizer* doubleTap = [[UITapGestureRecognizer alloc]
         initWithTarget:self action:@selector(laterPushed:)];
@@ -281,11 +311,58 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     [doubleTap release];*/
 }
 
+-(void)slideAwayRight
+{
+    if (!alertIsShowingPopOver && isAnimationInProgress == NO) {
+        if (index != 0) {
+            isAnimationInProgress = YES;
+            // Animate slide away to right of screen (newer notification)
+            [UIView beginAnimations:@"slideAwayToRight" context:nil];
+                [UIView setAnimationDelegate:self];
+                [UIView setAnimationDidStopSelector:@selector(animationDidStop:didFinish:inContext:)];
+                [UIView setAnimationCurve:UIViewAnimationCurveEaseIn];
+                [UIView setAnimationDuration:0.2];
+                [notificationView setFrame:CGRectMake(320,0,320,40)];
+            [UIView commitAnimations];
+            --index;
+        }
+    }
+}
+
+-(void)slideAwayLeft
+{
+    if (!alertIsShowingPopOver && isAnimationInProgress == NO) {
+        if (index < [pendingAlerts count] - 1) {
+            isAnimationInProgress = YES;
+            // Animate slide away to left of screen (older notification)
+            [UIView beginAnimations:@"slideAwayToLeft" context:nil];
+                [UIView setAnimationDelegate:self];
+                [UIView setAnimationDidStopSelector:@selector(animationDidStop:didFinish:inContext:)];
+                [UIView setAnimationCurve:UIViewAnimationCurveEaseIn];
+                [UIView setAnimationDuration:0.2];
+                [notificationView setFrame:CGRectMake(-320,0,320,40)];
+            [UIView commitAnimations];
+            ++index;
+        }
+    }
+}
+
+-(void)slideIn
+{
+    [UIView beginAnimations:@"slideIn" context:nil];
+        [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
+        [UIView setAnimationDuration:0.2];
+        [notificationView setFrame:CGRectMake(0,0,320,40)];
+    [UIView commitAnimations];
+}
+
 -(void)chevronPushed:(id)sender
 {
     [_delegate alertShowingPopOver:!alertIsShowingPopOver];
     if (alertIsShowingPopOver)
     {
+        [notificationScrollView setScrollEnabled:YES];
+        
         CGRect frame = self.view.frame;
         frame.size.height -= 229;
         self.view.frame = frame;
@@ -294,6 +371,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     }
     else
     {
+        [notificationScrollView setScrollEnabled:NO];
+        
         CGRect frame = self.view.frame;
         frame.size.height += 229;
         self.view.frame = frame;
@@ -385,6 +464,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         [detailText                           setAlpha:0.0];
         [dateText                             setAlpha:0.0];
         [closeButton                          setAlpha:0.0];
+        [notificationView                     setAlpha:0.0];
 
         if (dataObj.type == kSMSAlert)
         {
@@ -411,11 +491,28 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         [alertHeaderLabel         setAlpha:1.0];
         [alertTextLabel           setAlpha:1.0];
         [alertExpandButton        setAlpha:1.0];
+        [notificationView         setAlpha:1.0];
     [UIView commitAnimations];
 }
 
 -(void)animationDidStop:(NSString*)animationID didFinish:(NSNumber*)finished inContext:(id)context
 {
+    if ([animationID isEqualToString:@"slideAwayToRight"]) {
+        // Set the position back to the left side of the screen to be animated back in, going right
+        // loadViewInfo will do the moving for us
+        notificationViewRect = CGRectMake(-320,0,320,40);
+    }
+    else if ([animationID isEqualToString:@"slideAwayToLeft"]) {
+        // Set the position back to the right side of the screen to be animated back in, going left
+        // loadViewInfo will do the moving for us
+        notificationViewRect = CGRectMake(320,0,320,40);
+    }
+    if ([animationID isEqualToString:@"slideAwayToRight"] || [animationID isEqualToString:@"slideAwayToLeft"]) {
+        isAnimationInProgress = NO;
+        [self loadData];
+        [self slideIn];
+    }
+    
     if ([animationID isEqualToString:@"fadeInView"])
     {
         [alertActionBackgroundImageView removeFromSuperview];
@@ -437,6 +534,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     {
         [self.view removeFromSuperview];
     }
+}
+
+-(void)loadData
+{    
+    dataObj = [pendingAlerts objectAtIndex:index];
+    
+    [self loadViewInfo];
 }
 
 -(void)openPushed:(id)sender
@@ -499,11 +603,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -(void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (scrollView.contentOffset.x != 0.0)
+    if (scrollView == notificationScrollView) {
+        // If scroll was far enough to the left
+        if ([notificationScrollView contentOffset].x > 60) {
+            [self slideAwayLeft];
+        }
+        // If scroll was far enough to the right
+        else if ([notificationScrollView contentOffset].x < -60) {
+            [self slideAwayRight];
+        }
+    }
+    else if (scrollView.contentOffset.x != 0.0)
     {
         [scrollView setContentOffset: CGPointMake(0.0, scrollView.contentOffset.y)];
     }
 }
 
 @end
-


### PR DESCRIPTION
This basically works by placing the notification alert view objects (iconImageView, alertHeaderLabel, alertTextLabel and alertExpandButton) into a UIView, then placing the UIView into a UIScrollView.
The user can scroll the UIScrollView and when the contentOffset has moved far enough to the left or right, it animates the UIView away and out of the screen, changes the data to the next or previous notification (depending on direction swiped/scrolled).

It’s not perfect yet, two issues:
1) Looks a bit weird how the icon placeholder on the image is just left there. Would need to edit the image to fix the problem

2) There needs to be a way to tell when a notification view starts and ends. Use of black/grey lines as separators would work fine here, but couldn’t find a good way of doing that without resorting to using quartz, and that’s probably overkill just to draw two lines.

I have a solution that would fix 1) and improve the swiping animations at the same time to feel more natural but I’m probably not experienced enough yet to handle that + exams start this week :/
It’s basically that it would have two “UIView *notificationView” objects and move/animate them around, changing data on each when appropriate etc.

I’m not sure if you guys wanted this feature or not, but it was requested and I liked the idea so thought I would give it a shot.

If you think theres a better way to do this or you think this could be improved more, let me know ;)

It’s late now but If you have any questions or anything I’ll be back tomorrow (well… in a few hours :P )

Edit: I forgot to change the keyboard appearance back to semi-transparent... Not sure how to edit a pull request, sorry

Extra info: I Made a few little changes to the code originally in the file. I tried to make as little changes as possible but in the end had to make some to avoid a massive amount of code duplication, and to avoid some bugs/errors and improve efficiency. It all works the same as it did before though, that hasn't changed.
